### PR TITLE
PBX-30: Resolve build issues caused by upgrading nklib in PBX-26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DEPS_DIR = $(ROOT)/deps
 
 RELX = $(DEPS_DIR)/relx
 ELVIS = $(DEPS_DIR)/elvis
+FMT = $(ROOT)/make/erlang-formatter/fmt.sh
 TAGS = $(ROOT)/TAGS
 ERLANG_MK_COMMIT = 43533ac6bc2112beaa229bbb3fe5cd73a116ecda
 

--- a/applications/fax/deps.mk
+++ b/applications/fax/deps.mk
@@ -1,9 +1,7 @@
-DEPS = cowboy escalus exml gen_smtp lager ra
+DEPS = cowboy escalus exml gen_smtp lager
 
 dep_escalus = git https://github.com/esl/escalus 4.2.11
 # used by fax cloud printer i think?
 
 dep_exml = git https://github.com/2600hz/erlang-exml 2.2.1
 # used by fax cloud printer
-
-dep_ra = git https://github.com/2600hz/erlang-ra.git v1.0.4

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -25,7 +25,6 @@ DEPS ?= amqp_client \
 	lager \
 	lager_syslog \
 	meck \
-	qdate_localtime \
 	nklib \
 	plists \
 	poolboy \
@@ -35,7 +34,13 @@ DEPS ?= amqp_client \
 	reloader \
 	syslog \
 	wsock \
-	zucchini
+	zucchini \
+	enotify \
+	yamerl \
+	jsone \
+	mimerl \
+	eper \
+	parsexml
 
 BUILD_DEPS = parse_trans
 IGNORE_DEPS = hamcrest
@@ -64,8 +69,7 @@ dep_eiconv = git https://github.com/zotonic/eiconv
 # dep_exml = git https://github.com/paulgray/exml 2.2.1
 dep_jiffy = git https://github.com/lazedo/jiffy utf8  ## utf8 decode
 dep_meck = git https://github.com/eproxus/meck
-dep_qdate_localtime = git https://github.com/choptastic/qdate_localtime 1.2.1
-dep_nklib = git https://github.com/NetComposer/nklib 1f29f8f566586618651e4680dcc488f2dc11ff5c # Latest SHA from nklib master branch
+dep_nklib = git https://github.com/NetComposer/nklib a476c4aee9085f667cb1a91eb3db07319917d28a # SHA before Timezone changes to nklib
 dep_plists = git https://github.com/vonix-networks/plists 1.0.1-vonix
 
 dep_erlcloud = git https://github.com/erlcloud/erlcloud 3.2.4
@@ -117,3 +121,10 @@ dep_gen_smtp = git https://github.com/2600hz/erlang-gen_smtp 3f80bfcd4fd8704739d
 ## latest commit to origin/2600Hz: Fixes for encoding email address in a single comma separated header line
 
 dep_wsock = git https://github.com/vonix-networks/wsock 1.1.8-vonix
+
+dep_enotify = hex 0.1.0
+dep_yamerl = hex 0.10.0
+dep_jsone = hex 1.8.1
+dep_mimerl = hex 1.2.0
+dep_eper = hex 0.99.1
+dep_parsexml = hex 1.0.0


### PR DESCRIPTION
- Used commit before Timezone changes to nklib repo
- As nklib not downloading its transitive dependencies we added them to make/deps.mk
- Removed ra from applications/fax deps.mk file
- Added FMT back which was removed in PBX-14